### PR TITLE
[Fix] Update example.config.js

### DIFF
--- a/data/example.config.js
+++ b/data/example.config.js
@@ -3,11 +3,11 @@
 	"channels":["#test"],
 	"nick":"TestBot",
 
-	"debug": "false",
-	"port": "7000",
-	"secure": "true",
-	"certExpired": "true",
-	"selfSigned": "true",
+	"debug": false,
+	"port": 6697,
+	"secure": true,
+	"certExpired": true,
+	"selfSigned": true,
 
 	"groove":"api_key",
 
@@ -25,6 +25,6 @@
 	"greeting": ["Konnichiwa", "Welcome"],
 	"greeting-ignore": ["GitBot"],
 
-	"modules": ["lastfm", "replace", "grooveshark", "issues", "greeting", "searchLink"],
+	"modules": ["lastfm", "replace", "grooveshark", "issues", "greeting", "searchLink", "kill"],
 	"admin": ["admin"]
 }


### PR DESCRIPTION
- Replace port 7000 by IRC SSL default port (6697).
- Fix JSON syntax that cause the client does not interpret the values ​​correctly. (debug, port, secure, certExpired, selfSigned)
- Add kill module into the modules array.
