### PR TITLE
Fix for the Calc module

### DIFF
--- a/modules/calc.js
+++ b/modules/calc.js
@@ -1,35 +1,31 @@
-var http = require('http');
+var mathjs = require("mathjs")();
+
 var Calculator = function() {
 	//Constructor
-}
+};
 
 Calculator.prototype = {
 	handle: function(from, chan, message) {
 		var irc = global.irc;
 		
-		if (matches = message.match(/^!calc (.*)$/i)) {
+		var matches = message.match(/^!calc (.*)$/i);
+		if (matches && matches.length >= 1) {
 			var input = matches[1].trim();
-			var callback = function(response) {
-				var str = '';
 			
-				response.on('data', function (chunk) {
-					str += chunk;
-				});
-				
-				response.on('end', function () {
-					/* var data = JSON.parse(str);
-					
-					if (data['error']) irc.client.say(chan, input + ': Error');
-					else irc.client.say(chan, input + ' = ' + data['rhs']); */
-
-					if (result = str.match(/rhs: "([^"]+)"/i))
-						irc.client.say(chan, input + ' = ' + result[1]);
-					else
-						irc.client.say(chan, "Error: " + input);
-				});
+			if(input === '') {
+				return;
 			}
-			
-			http.request({ host: 'www.google.com', path: '/ig/calculator?hl=en&q=' + encodeURIComponent(input) }, callback).end();
+
+			try {
+				// jsHint tags mathjs.eval as eval, which it is not. 
+				// see https://github.com/josdejong/mathjs/blob/master/docs/expressions.md#eval
+				/* jshint evil: true */
+				var result = mathjs.eval(input);
+
+				irc.client.say(chan, input + ' = ' + result);
+			} catch(e) {
+				console.log("Calculator Error: " + e);
+			}
 		}
 	}
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "node": ">=0.6"
   },
   "dependencies": {
+  "mathjs": "0.18.x",
 	"mysql": "2.1.x",
 	"irc": "0.3.x", 
 	"lastfm": "0.9.x",


### PR DESCRIPTION
The old module was using a private API that has been retired by google. The new version uses the mathjs library to locally parse the math expressions.
