### PR TITLE
grunt-cli as local dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - 0.11
-before_script:
-  - npm install -g grunt-cli
+  - 0.10
 notifications:
     email: false

--- a/package.json
+++ b/package.json
@@ -26,23 +26,24 @@
   "engines": {
     "node": ">=0.6"
   },
-  "scripts" : {
+  "scripts": {
     "test": "grunt test"
   },
   "devDependencies": {
+    "chai": "*",
     "grunt": "0.4.x",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "0.9.x",
-    "grunt-mocha-test": "0.9.x",
-    "chai": "*"
+    "grunt-mocha-test": "0.9.x"
   },
   "dependencies": {
-  "mathjs": "0.18.x",
-	"mysql": "2.1.x",
-	"irc": "0.3.x", 
-	"lastfm": "0.9.x",
-	"bitly": "1.2.x",
-	"bars": "https://github.com/jstrace/bars/tarball/master"
+    "mathjs": "0.18.x",
+    "mysql": "2.1.x",
+    "irc": "0.3.x",
+    "lastfm": "0.9.x",
+    "bitly": "1.2.x",
+    "bars": "https://github.com/jstrace/bars/tarball/master"
   },
-  "readme": "", 
+  "readme": "",
   "readmeFilename": "README.md"
 }


### PR DESCRIPTION
This change should allow for;

```
> git clone ...
> npm install
> npm test
```

Directly, without globally installing grunt-cli.
